### PR TITLE
Cria endpoint para listar os lunch items

### DIFF
--- a/src/main/java/com/challenge/fastfood/adapter/in/controller/LunchItemsController.java
+++ b/src/main/java/com/challenge/fastfood/adapter/in/controller/LunchItemsController.java
@@ -1,18 +1,17 @@
 package com.challenge.fastfood.adapter.in.controller;
 
+import com.challenge.fastfood.adapter.in.controller.request.LunchItemRequest;
 import com.challenge.fastfood.adapter.in.controller.response.LunchItemResponse;
 import com.challenge.fastfood.adapter.out.mapstruct.LunchItemMapper;
 import com.challenge.fastfood.domain.entities.LunchItem;
 import com.challenge.fastfood.domain.entities.LunchItemType;
+import com.challenge.fastfood.domain.ports.in.CreateLunchItemUseCasePort;
 import com.challenge.fastfood.domain.ports.in.FindLunchItemsUseCasePort;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -22,6 +21,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LunchItemsController {
 
+    private final CreateLunchItemUseCasePort createLunchItemUseCasePort;
     private final FindLunchItemsUseCasePort findLunchItemsUseCasePort;
     private final LunchItemMapper lunchItemMapper;
 
@@ -36,5 +36,12 @@ public class LunchItemsController {
         }
         List<LunchItem> lunchItemList = findLunchItemsUseCasePort.findLunchItems(lunchItemType);
         return ResponseEntity.ok(lunchItemMapper.lunchItemToLunchItemResponse(lunchItemList));
+    }
+
+    @PostMapping
+    @Operation(summary = "Create a lunch item", description = "Create a lunch item")
+    public ResponseEntity<LunchItemResponse> createLunchItem(@RequestBody LunchItemRequest lunchItemRequest) {
+        LunchItem lunchItem = createLunchItemUseCasePort.createLunchItem(lunchItemMapper.lunchItemRequestToLunchItem(lunchItemRequest));
+        return ResponseEntity.ok(lunchItemMapper.lunchItemToLunchItemResponse(lunchItem));
     }
 }

--- a/src/main/java/com/challenge/fastfood/adapter/in/controller/LunchItemsController.java
+++ b/src/main/java/com/challenge/fastfood/adapter/in/controller/LunchItemsController.java
@@ -1,0 +1,35 @@
+package com.challenge.fastfood.adapter.in.controller;
+
+import com.challenge.fastfood.adapter.in.controller.response.LunchItemResponse;
+import com.challenge.fastfood.adapter.out.mapstruct.LunchItemMapper;
+import com.challenge.fastfood.domain.entities.LunchItem;
+import com.challenge.fastfood.domain.entities.LunchItemType;
+import com.challenge.fastfood.domain.ports.in.FindLunchItemsUseCasePort;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/lunch-items")
+@Tag(name = "LunchItems", description = "Client Controller")
+@RequiredArgsConstructor
+public class LunchItemsController {
+
+    private final FindLunchItemsUseCasePort findLunchItemsUseCasePort;
+    private final LunchItemMapper lunchItemMapper;
+
+    @GetMapping
+    @Operation(summary = "Get available lunch items", description = "Get available lunch items")
+    public ResponseEntity<List<LunchItemResponse>> getLunchItems(@RequestParam(required = false) String type) {
+        LunchItemType lunchItemType = type == null ? null : LunchItemType.valueOf(type.toUpperCase());
+        List<LunchItem> lunchItemList = findLunchItemsUseCasePort.findLunchItems(lunchItemType);
+        return ResponseEntity.ok(lunchItemMapper.lunchItemToLunchItemResponse(lunchItemList));
+    }
+}

--- a/src/main/java/com/challenge/fastfood/adapter/in/controller/LunchItemsController.java
+++ b/src/main/java/com/challenge/fastfood/adapter/in/controller/LunchItemsController.java
@@ -28,7 +28,12 @@ public class LunchItemsController {
     @GetMapping
     @Operation(summary = "Get available lunch items", description = "Get available lunch items")
     public ResponseEntity<List<LunchItemResponse>> getLunchItems(@RequestParam(required = false) String type) {
-        LunchItemType lunchItemType = type == null ? null : LunchItemType.valueOf(type.toUpperCase());
+        LunchItemType lunchItemType;
+        try {
+            lunchItemType = type == null ? null : LunchItemType.valueOf(type.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(List.of());
+        }
         List<LunchItem> lunchItemList = findLunchItemsUseCasePort.findLunchItems(lunchItemType);
         return ResponseEntity.ok(lunchItemMapper.lunchItemToLunchItemResponse(lunchItemList));
     }

--- a/src/main/java/com/challenge/fastfood/adapter/in/controller/request/ClientRequest.java
+++ b/src/main/java/com/challenge/fastfood/adapter/in/controller/request/ClientRequest.java
@@ -1,7 +1,6 @@
 package com.challenge.fastfood.adapter.in.controller.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 
 public record ClientRequest(
         @Schema(description = "The name of the client", example = "Jequelia")
@@ -10,8 +9,4 @@ public record ClientRequest(
         String email,
         @Schema(description = "The cpf of the client", example = "123.456.789-00")
         String cpf) {
-
-
-
-
 }

--- a/src/main/java/com/challenge/fastfood/adapter/in/controller/request/LunchItemRequest.java
+++ b/src/main/java/com/challenge/fastfood/adapter/in/controller/request/LunchItemRequest.java
@@ -1,0 +1,12 @@
+package com.challenge.fastfood.adapter.in.controller.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LunchItemRequest(
+        @Schema(description = "The name of the lunch item", example = "Hamburger")
+        String name,
+        @Schema(description = "The price of the lunch item with two decimal points", example = "12.34")
+        Float price,
+        @Schema(description = "The type of the lunch item", example = "snack")
+        String type) {
+}

--- a/src/main/java/com/challenge/fastfood/adapter/in/controller/response/ClientResponse.java
+++ b/src/main/java/com/challenge/fastfood/adapter/in/controller/response/ClientResponse.java
@@ -7,6 +7,4 @@ public record ClientResponse(
         String name,
         @Schema(description = "The email of the client", example = "jequelia@email.com")
         String email) {
-
-
 }

--- a/src/main/java/com/challenge/fastfood/adapter/in/controller/response/LunchItemResponse.java
+++ b/src/main/java/com/challenge/fastfood/adapter/in/controller/response/LunchItemResponse.java
@@ -1,0 +1,13 @@
+package com.challenge.fastfood.adapter.in.controller.response;
+
+import com.challenge.fastfood.domain.entities.LunchItemType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LunchItemResponse(
+    @Schema(description = "The name of the lunch item", example = "Hamburger")
+    String name,
+    @Schema(description = "The price of the lunch item", example = "1.42")
+    float price,
+    @Schema(description = "The type of the lunch item", example = "Snack")
+    LunchItemType type) {
+}

--- a/src/main/java/com/challenge/fastfood/adapter/out/mapstruct/LunchItemMapper.java
+++ b/src/main/java/com/challenge/fastfood/adapter/out/mapstruct/LunchItemMapper.java
@@ -1,5 +1,6 @@
 package com.challenge.fastfood.adapter.out.mapstruct;
 
+import com.challenge.fastfood.adapter.in.controller.request.LunchItemRequest;
 import com.challenge.fastfood.adapter.in.controller.response.LunchItemResponse;
 import com.challenge.fastfood.adapter.out.repository.LunchItemEntity;
 import com.challenge.fastfood.domain.entities.LunchItem;
@@ -10,6 +11,8 @@ import java.util.List;
 
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface LunchItemMapper {
+
+    LunchItem lunchItemRequestToLunchItem(LunchItemRequest lunchItemRequest);
 
     LunchItemResponse lunchItemToLunchItemResponse(LunchItem lunchItem);
     List<LunchItemResponse> lunchItemToLunchItemResponse(List<LunchItem> lunchItems);

--- a/src/main/java/com/challenge/fastfood/adapter/out/mapstruct/LunchItemMapper.java
+++ b/src/main/java/com/challenge/fastfood/adapter/out/mapstruct/LunchItemMapper.java
@@ -1,0 +1,22 @@
+package com.challenge.fastfood.adapter.out.mapstruct;
+
+import com.challenge.fastfood.adapter.in.controller.response.LunchItemResponse;
+import com.challenge.fastfood.adapter.out.repository.LunchItemEntity;
+import com.challenge.fastfood.domain.entities.LunchItem;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+import java.util.List;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface LunchItemMapper {
+
+    LunchItemResponse lunchItemToLunchItemResponse(LunchItem lunchItem);
+    List<LunchItemResponse> lunchItemToLunchItemResponse(List<LunchItem> lunchItems);
+
+    LunchItemEntity lunchItemToLunchItemEntity(LunchItem lunchItem);
+    List<LunchItemEntity> lunchItemToLunchItemEntity(List<LunchItem> lunchItems);
+
+    LunchItem lunchItemEntityToLunchItem(LunchItemEntity lunchItemEntity);
+    List<LunchItem> lunchItemEntityToLunchItem(List<LunchItemEntity> lunchItemEntities);
+}

--- a/src/main/java/com/challenge/fastfood/adapter/out/repository/FindLunchItemsAdapter.java
+++ b/src/main/java/com/challenge/fastfood/adapter/out/repository/FindLunchItemsAdapter.java
@@ -1,0 +1,25 @@
+package com.challenge.fastfood.adapter.out.repository;
+
+import com.challenge.fastfood.adapter.out.mapstruct.LunchItemMapper;
+import com.challenge.fastfood.domain.entities.LunchItem;
+import com.challenge.fastfood.domain.entities.LunchItemType;
+import com.challenge.fastfood.domain.ports.out.FindLunchItemsAdapterPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class FindLunchItemsAdapter implements FindLunchItemsAdapterPort {
+
+    private final LunchItemsRepository lunchItemsRepository;
+    private final LunchItemMapper lunchItemMapper;
+
+    @Override
+    public List<LunchItem> findLunchItems(LunchItemType type) {
+        List<LunchItemEntity> lunchItemEntity = lunchItemsRepository.findByType(type);
+        return lunchItemMapper.lunchItemEntityToLunchItem(lunchItemEntity);
+    }
+
+}

--- a/src/main/java/com/challenge/fastfood/adapter/out/repository/LunchItemEntity.java
+++ b/src/main/java/com/challenge/fastfood/adapter/out/repository/LunchItemEntity.java
@@ -1,0 +1,29 @@
+package com.challenge.fastfood.adapter.out.repository;
+
+import com.challenge.fastfood.domain.entities.LunchItemType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Table(name = "lunch_item")
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode(of = "id")
+public class LunchItemEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type")
+    private LunchItemType type;
+
+    @Column(name = "price")
+    private float price;
+}

--- a/src/main/java/com/challenge/fastfood/adapter/out/repository/LunchItemsRepository.java
+++ b/src/main/java/com/challenge/fastfood/adapter/out/repository/LunchItemsRepository.java
@@ -1,0 +1,13 @@
+package com.challenge.fastfood.adapter.out.repository;
+
+import com.challenge.fastfood.domain.entities.LunchItemType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface LunchItemsRepository extends JpaRepository<LunchItemEntity, Long> {
+
+    List<LunchItemEntity> findByType(LunchItemType lunchItemType);
+}

--- a/src/main/java/com/challenge/fastfood/adapter/out/repository/SaveLunchItemAdapter.java
+++ b/src/main/java/com/challenge/fastfood/adapter/out/repository/SaveLunchItemAdapter.java
@@ -1,0 +1,23 @@
+package com.challenge.fastfood.adapter.out.repository;
+
+import com.challenge.fastfood.adapter.out.mapstruct.LunchItemMapper;
+import com.challenge.fastfood.domain.entities.LunchItem;
+import com.challenge.fastfood.domain.ports.out.SaveLunchItemAdapterPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SaveLunchItemAdapter implements SaveLunchItemAdapterPort {
+
+    private final LunchItemsRepository lunchItemsRepository;
+    private final LunchItemMapper lunchItemMapper;
+
+    @Override
+    public LunchItem saveLunchItem(LunchItem lunchItem) {
+        LunchItemEntity lunchItemEntity = lunchItemMapper.lunchItemToLunchItemEntity(lunchItem);
+        LunchItemEntity lunchItemEntitySaved = lunchItemsRepository.save(lunchItemEntity);
+
+        return lunchItemMapper.lunchItemEntityToLunchItem(lunchItemEntitySaved);
+    }
+}

--- a/src/main/java/com/challenge/fastfood/config/Config.java
+++ b/src/main/java/com/challenge/fastfood/config/Config.java
@@ -1,9 +1,11 @@
 package com.challenge.fastfood.config;
 
 import com.challenge.fastfood.domain.ports.out.FindClientAdapterPort;
+import com.challenge.fastfood.domain.ports.out.FindLunchItemsAdapterPort;
 import com.challenge.fastfood.domain.ports.out.SaveClientAdapterPort;
 import com.challenge.fastfood.domain.usecase.CreateClientUseCase;
 import com.challenge.fastfood.domain.usecase.FindClientUseCase;
+import com.challenge.fastfood.domain.usecase.FindLunchItemsUseCase;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -18,6 +20,11 @@ public class Config {
     @Bean
     public FindClientUseCase findClientUseCase(FindClientAdapterPort findClientAdapterPort) {
         return new FindClientUseCase(findClientAdapterPort);
+    }
+
+    @Bean
+    public FindLunchItemsUseCase findLunchItemsUseCase(FindLunchItemsAdapterPort findLunchItemsAdapterPort) {
+        return new FindLunchItemsUseCase(findLunchItemsAdapterPort);
     }
 
 

--- a/src/main/java/com/challenge/fastfood/config/Config.java
+++ b/src/main/java/com/challenge/fastfood/config/Config.java
@@ -3,7 +3,9 @@ package com.challenge.fastfood.config;
 import com.challenge.fastfood.domain.ports.out.FindClientAdapterPort;
 import com.challenge.fastfood.domain.ports.out.FindLunchItemsAdapterPort;
 import com.challenge.fastfood.domain.ports.out.SaveClientAdapterPort;
+import com.challenge.fastfood.domain.ports.out.SaveLunchItemAdapterPort;
 import com.challenge.fastfood.domain.usecase.CreateClientUseCase;
+import com.challenge.fastfood.domain.usecase.CreateLunchItemUseCase;
 import com.challenge.fastfood.domain.usecase.FindClientUseCase;
 import com.challenge.fastfood.domain.usecase.FindLunchItemsUseCase;
 import org.springframework.context.annotation.Bean;
@@ -20,6 +22,11 @@ public class Config {
     @Bean
     public FindClientUseCase findClientUseCase(FindClientAdapterPort findClientAdapterPort) {
         return new FindClientUseCase(findClientAdapterPort);
+    }
+
+    @Bean
+    public CreateLunchItemUseCase createLunchItemUseCase(SaveLunchItemAdapterPort saveLunchItemAdapterPort) {
+        return new CreateLunchItemUseCase(saveLunchItemAdapterPort);
     }
 
     @Bean

--- a/src/main/java/com/challenge/fastfood/domain/entities/Lunch.java
+++ b/src/main/java/com/challenge/fastfood/domain/entities/Lunch.java
@@ -7,18 +7,28 @@ import com.challenge.fastfood.domain.valueObjects.Snack;
 
 public class Lunch {
 
+    private Client client;
     private Snack snack;
     private Accompaniment accompaniment;
     private Drink drink;
     private Dessert dessert;
     private double priceTotal;
 
-    public Lunch(Snack snack, Accompaniment accompaniment, Drink drink, Dessert dessert) {
+    public Lunch(Client client, Snack snack, Accompaniment accompaniment, Drink drink, Dessert dessert) {
+        this.client = client;
         this.snack = snack;
         this.accompaniment = accompaniment;
         this.drink = drink;
         this.dessert = dessert;
         this.priceTotal = snack.getTotalPrice() + accompaniment.getTotalPrice() + drink.getTotalPrice() + dessert.getTotalPrice();
+    }
+
+    public Client getClient() {
+        return client;
+    }
+
+    public void setClient(Client client) {
+        this.client = client;
     }
 
     public double getPriceTotal() {
@@ -41,7 +51,7 @@ public class Lunch {
         return accompaniment;
     }
 
-public void setAccompaniment(Accompaniment accompaniment) {
+    public void setAccompaniment(Accompaniment accompaniment) {
         this.accompaniment = accompaniment;
     }
 

--- a/src/main/java/com/challenge/fastfood/domain/entities/LunchItem.java
+++ b/src/main/java/com/challenge/fastfood/domain/entities/LunchItem.java
@@ -1,0 +1,24 @@
+package com.challenge.fastfood.domain.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class LunchItem {
+
+    private Long id;
+    private String name;
+    private Float price;
+    private LunchItemType type;
+
+    public LunchItem(String name, Float price, LunchItemType type) {
+        this.name = name;
+        this.price = price;
+        this.type = type;
+    }
+}

--- a/src/main/java/com/challenge/fastfood/domain/entities/LunchItemType.java
+++ b/src/main/java/com/challenge/fastfood/domain/entities/LunchItemType.java
@@ -1,0 +1,8 @@
+package com.challenge.fastfood.domain.entities;
+
+public enum LunchItemType {
+    SNACK,
+    ACCOMPANIMENT,
+    DRINK,
+    DESSERT
+}

--- a/src/main/java/com/challenge/fastfood/domain/ports/in/CreateClientUseCasePort.java
+++ b/src/main/java/com/challenge/fastfood/domain/ports/in/CreateClientUseCasePort.java
@@ -4,6 +4,6 @@ import com.challenge.fastfood.domain.entities.Client;
 
 public interface CreateClientUseCasePort {
 
-    Client createClient(Client example);
+    Client createClient(Client client);
 
 }

--- a/src/main/java/com/challenge/fastfood/domain/ports/in/CreateLunchItemUseCasePort.java
+++ b/src/main/java/com/challenge/fastfood/domain/ports/in/CreateLunchItemUseCasePort.java
@@ -1,0 +1,8 @@
+package com.challenge.fastfood.domain.ports.in;
+
+import com.challenge.fastfood.domain.entities.LunchItem;
+
+public interface CreateLunchItemUseCasePort {
+
+    LunchItem createLunchItem(LunchItem lunchItem);
+}

--- a/src/main/java/com/challenge/fastfood/domain/ports/in/FindLunchItemsUseCasePort.java
+++ b/src/main/java/com/challenge/fastfood/domain/ports/in/FindLunchItemsUseCasePort.java
@@ -1,0 +1,11 @@
+package com.challenge.fastfood.domain.ports.in;
+
+import com.challenge.fastfood.domain.entities.LunchItem;
+import com.challenge.fastfood.domain.entities.LunchItemType;
+
+import java.util.List;
+
+public interface FindLunchItemsUseCasePort {
+
+    List<LunchItem> findLunchItems(LunchItemType type);
+}

--- a/src/main/java/com/challenge/fastfood/domain/ports/out/FindLunchItemsAdapterPort.java
+++ b/src/main/java/com/challenge/fastfood/domain/ports/out/FindLunchItemsAdapterPort.java
@@ -1,0 +1,11 @@
+package com.challenge.fastfood.domain.ports.out;
+
+import com.challenge.fastfood.domain.entities.LunchItem;
+import com.challenge.fastfood.domain.entities.LunchItemType;
+
+import java.util.List;
+
+public interface FindLunchItemsAdapterPort {
+
+    List<LunchItem> findLunchItems(LunchItemType lunchItemType);
+}

--- a/src/main/java/com/challenge/fastfood/domain/ports/out/SaveLunchItemAdapterPort.java
+++ b/src/main/java/com/challenge/fastfood/domain/ports/out/SaveLunchItemAdapterPort.java
@@ -1,0 +1,8 @@
+package com.challenge.fastfood.domain.ports.out;
+
+import com.challenge.fastfood.domain.entities.LunchItem;
+
+public interface SaveLunchItemAdapterPort {
+
+    LunchItem saveLunchItem(LunchItem lunchItem);
+}

--- a/src/main/java/com/challenge/fastfood/domain/usecase/CreateLunchItemUseCase.java
+++ b/src/main/java/com/challenge/fastfood/domain/usecase/CreateLunchItemUseCase.java
@@ -1,0 +1,19 @@
+package com.challenge.fastfood.domain.usecase;
+
+import com.challenge.fastfood.domain.entities.LunchItem;
+import com.challenge.fastfood.domain.ports.in.CreateLunchItemUseCasePort;
+import com.challenge.fastfood.domain.ports.out.SaveLunchItemAdapterPort;
+
+public class CreateLunchItemUseCase implements CreateLunchItemUseCasePort {
+
+    private final SaveLunchItemAdapterPort saveLunchItemAdapterPort;
+
+    public CreateLunchItemUseCase(SaveLunchItemAdapterPort saveLunchItemAdapterPort) {
+        this.saveLunchItemAdapterPort = saveLunchItemAdapterPort;
+    }
+
+    @Override
+    public LunchItem createLunchItem(LunchItem lunchItem) {
+        return saveLunchItemAdapterPort.saveLunchItem(lunchItem);
+    }
+}

--- a/src/main/java/com/challenge/fastfood/domain/usecase/FindLunchItemsUseCase.java
+++ b/src/main/java/com/challenge/fastfood/domain/usecase/FindLunchItemsUseCase.java
@@ -1,0 +1,22 @@
+package com.challenge.fastfood.domain.usecase;
+
+import com.challenge.fastfood.domain.entities.LunchItem;
+import com.challenge.fastfood.domain.entities.LunchItemType;
+import com.challenge.fastfood.domain.ports.in.FindLunchItemsUseCasePort;
+import com.challenge.fastfood.domain.ports.out.FindLunchItemsAdapterPort;
+
+import java.util.List;
+
+public class FindLunchItemsUseCase implements FindLunchItemsUseCasePort {
+
+    private final FindLunchItemsAdapterPort findLunchItemsAdapterPort;
+
+    public FindLunchItemsUseCase(FindLunchItemsAdapterPort findLunchItemsAdapterPort) {
+        this.findLunchItemsAdapterPort = findLunchItemsAdapterPort;
+    }
+
+    @Override
+    public List<LunchItem> findLunchItems(LunchItemType type) {
+        return findLunchItemsAdapterPort.findLunchItems(type);
+    }
+}

--- a/src/main/resources/db/migration/V2__create-table-lunch_item.sql
+++ b/src/main/resources/db/migration/V2__create-table-lunch_item.sql
@@ -2,6 +2,6 @@ CREATE TABLE lunch_item (
      id BIGINT NOT NULL AUTO_INCREMENT,
      name VARCHAR(100) NOT NULL UNIQUE,
      type VARCHAR(100) NOT NULL,
-     price DECIMAL(3,2) NOT NULL,
+     price DECIMAL(4,2) NOT NULL,
      PRIMARY KEY(id)
 );


### PR DESCRIPTION
Cria o endpoint para listar os lunch items.

Recebe um parâmetro: 'type', que pode ser nulo. Tipos permitidos são `SNACK`, `LUNCH`, `ACCOMPANIMENT` e `DESSERT`.

Cria também o endpoint para criar lunch items. Ainda sem error handling adequado. Está expondo o stack trace pro cliente.